### PR TITLE
benchmark value and description tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,1 @@
+import pytest_benchmark


### PR DESCRIPTION
Uses pytest-benchmark to measure the execution time of:

1. name2oid translation
2. lookup of sysctl value or description