### PR TITLE
remove underscore from pip name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # py-freebsd_sysctl
 
-> A native Python module for FreeBSD sysctl.
+> Native Python wrapper for FreeBSD sysctls using libc.
 
 This Python 3 interface for FreeBSD sysctl has no third party dependency and does not require a compile step to install.
 It is meant for performant (read) access to sysctls, their type, value and description.

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with open(os.path.join(cwd, 'README.md'), encoding='utf-8') as f:
 setup(
 	name="freebsd-sysctl",
 	version=about['__version__'],
-	description="A native Python module for FreeBSD sysctl.",
+	description="Native Python wrapper for FreeBSD sysctls using libc.",
 	long_description=long_description,
 	long_description_content_type="text/markdown",
 	url="https://github.com/gronke/py-freebsd_sysctl",

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ setup(
 	author="Stefan Grönke",
 	author_email="stefan@gronke.net",
 	python_requires=">=3.6",
-	setup_requires=["pytest-runner"],
-	tests_require=["pytest"],
+	tests_require=["pytest-runner", "pytest"],
 	packages=find_packages(exclude=('tests',))
 )

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open(os.path.join(cwd, 'README.md'), encoding='utf-8') as f:
 
 
 setup(
-	name="freebsd_sysctl",
+	name="freebsd-sysctl",
 	version=about['__version__'],
 	description="A native Python module for FreeBSD sysctl.",
 	long_description=long_description,


### PR DESCRIPTION
Although the Python module is called `freebsd_sysctl`, the package name is `freebsd-sysctl`.

This was brought up in the discussion about the FreeBSD port https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=240920#c2