### PR TITLE
use ctypes.CDLL() directly instead of find_library

### DIFF
--- a/freebsd_sysctl/libc.py
+++ b/freebsd_sysctl/libc.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019, Stefan Grönke
+# Copyright (c) 2020, Stefan Grönke
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -21,5 +21,9 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
 # IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-import ctypes.util
-dll = ctypes.CDLL("libc.so")
+import ctypes
+try:
+    dll = ctypes.CDLL("libc.so.7")
+except OSError:
+    import ctypes.util
+    dll = ctypes.CDLL(str(ctypes.util.find_library("c")), use_errno=True)

--- a/freebsd_sysctl/libc.py
+++ b/freebsd_sysctl/libc.py
@@ -22,5 +22,4 @@
 # IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 import ctypes.util
-clib = ctypes.util.find_library("c")
-dll = ctypes.CDLL(clib)
+dll = ctypes.CDLL("libc.so")


### PR DESCRIPTION
This should be more efficient, as it doesn't need to call `ldconfig`,
`gcc`, `objdump` or `ld` to determine its existence.
`ctypes.CDDL()` will use `dlopen()` directly.

Note that we're hard-coding the current version (`libc.so.7`).
This will need changing when FreeBSD changes their ABI.

At that point we might have to rethink our strategy, or fix
`ctypes.util.find_library()` to be less awful.
Until then, this should give us a minimal performance boost.