### PR TITLE
Fix typing of query_fmt() and stop passing byte order/size/alighnment

### DIFF
--- a/freebsd_sysctl/__init__.py
+++ b/freebsd_sysctl/__init__.py
@@ -44,7 +44,7 @@ class Sysctl:
     _kind: typing.Optional[int]
     _fmt = typing.Optional[bytes]
     _size: typing.Optional[int]
-    _value: typing.Optional[str]
+    _value: typing.Optional[typing.Any]
     _description: typing.Optional[str]
 
     def __init__(
@@ -95,14 +95,16 @@ class Sysctl:
         return self._size
 
     @property
-    def raw_value(self) -> int:
+    def raw_value(self) -> typing.Any:
         if self._value is None:
             self._value = self.query_value(self.oid, self.size, self.ctl_type)
         return self._value
 
     @property
-    def value(self) -> int:
-        return self.raw_value.value.strip("\n")
+    def value(self) -> typing.Any:
+        if type(self.raw_value.value) == str:
+            return self.raw_value.value.strip("\n")
+        return self.raw_value.value
 
     @property
     def description(self) -> str:

--- a/freebsd_sysctl/__init__.py
+++ b/freebsd_sysctl/__init__.py
@@ -205,7 +205,7 @@ class Sysctl:
         result = buf[:buf_length]
         kind, = struct.unpack("I", result[:4])
         fmt = result[4:]
-        return (kind & 0xF, fmt)
+        return (kind, fmt)
 
     @staticmethod
     def query_size(

--- a/freebsd_sysctl/__init__.py
+++ b/freebsd_sysctl/__init__.py
@@ -176,7 +176,7 @@ class Sysctl:
         return buf.value.decode()
 
     @staticmethod
-    def query_fmt(oid: typing.List[int]) -> bytes:
+    def query_fmt(oid: typing.List[int]) -> typing.Tuple[int, bytes]:
 
         qoid_len = (2 + len(oid))
         qoid_type = ctypes.c_int * qoid_len
@@ -203,9 +203,9 @@ class Sysctl:
         if len(buf) < 4:
             raise Exception("response buffer too small")
         result = buf[:buf_length]
-        kind, = struct.unpack("<I", result[:4])
+        kind, = struct.unpack("I", result[:4])
         fmt = result[4:]
-        return (kind, fmt)
+        return (kind & 0xF, fmt)
 
     @staticmethod
     def query_size(

--- a/freebsd_sysctl/__init__.py
+++ b/freebsd_sysctl/__init__.py
@@ -174,7 +174,7 @@ class Sysctl:
         return buf.value.decode()
 
     @staticmethod
-    def query_fmt(oid: typing.List[int]) -> bytes:
+    def query_fmt(oid: typing.List[int]) -> typing.Tuple[int, bytes]:
 
         qoid_len = (2 + len(oid))
         qoid_type = ctypes.c_int * qoid_len
@@ -201,9 +201,9 @@ class Sysctl:
         if len(buf) < 4:
             raise Exception("response buffer too small")
         result = buf[:buf_length]
-        kind, = struct.unpack("<I", result[:4])
+        kind, = struct.unpack("I", result[:4])
         fmt = result[4:]
-        return (kind, fmt)
+        return (kind & 0xF, fmt)
 
     @staticmethod
     def query_size(

--- a/freebsd_sysctl/types.py
+++ b/freebsd_sysctl/types.py
@@ -25,13 +25,6 @@ import ctypes
 import typing
 import struct
 
-if struct.calcsize("P") == 4: # 32bit
-    unpack_format_long = "i"
-    unpack_format_ulong = "I"
-else: # assume 64bit - no 128bit yet
-    unpack_format_long = "q"
-    unpack_format_ulong = "Q"
-
 
 class CtlType:
     min_size = 0
@@ -115,13 +108,13 @@ class UINT(CtlType):
 class LONG(CtlType):
     ctype = ctypes.c_long
     min_size = ctypes.sizeof(ctypes.c_long)
-    unpack_format = unpack_format_long
+    unpack_format = "l"
 
 
 class ULONG(CtlType):
     ctype = ctypes.c_ulong
     min_size = ctypes.sizeof(ctypes.c_ulong)
-    unpack_format = unpack_format_ulong
+    unpack_format = "L"
 
 
 class U64(CtlType):

--- a/freebsd_sysctl/types.py
+++ b/freebsd_sysctl/types.py
@@ -25,6 +25,13 @@ import ctypes
 import typing
 import struct
 
+if struct.calcsize("P") == 4: # 32bit
+    unpack_format_long = "i"
+    unpack_format_ulong = "I"
+else: # assume 64bit - no 128bit yet
+    unpack_format_long = "q"
+    unpack_format_ulong = "Q"
+
 
 class CtlType:
     min_size = 0
@@ -108,13 +115,13 @@ class UINT(CtlType):
 class LONG(CtlType):
     ctype = ctypes.c_long
     min_size = ctypes.sizeof(ctypes.c_long)
-    unpack_format = "q"
+    unpack_format = unpack_format_long
 
 
 class ULONG(CtlType):
     ctype = ctypes.c_ulong
     min_size = ctypes.sizeof(ctypes.c_ulong)
-    unpack_format = "Q"
+    unpack_format = unpack_format_ulong
 
 
 class U64(CtlType):

--- a/freebsd_sysctl/types.py
+++ b/freebsd_sysctl/types.py
@@ -47,7 +47,7 @@ class CtlType:
         if self.unpack_format is None:
             return self.data.value
         values = list(struct.unpack(
-            f"<{self.unpack_format * self.amount}",
+            f"{self.unpack_format * self.amount}",
             self.data
         ))
         if len(values) == 1:


### PR DESCRIPTION
https://docs.python.org/3/library/struct.html#byte-order-size-and-alignment
"By default, C types are represented in the machine's native format and byte order, and properly aligned by skipping pad bytes if necessary (according to the rules used by the C compiler)."