### PR TITLE
Test a list of well known sysctls with parametrize.

### DIFF
--- a/tests/freebsd_sysctl_test.py
+++ b/tests/freebsd_sysctl_test.py
@@ -88,6 +88,32 @@ def test_sysctl_types(sysctl_types):
         assert sysctl_type == current_mapped_type, sysctl_name
 
 
+WELL_KNOWNS = [
+    # sysctl-type-name, sysctl name, sysctl -t
+    ["CTLTYPE_INT", "kern.osrevision", "integer"],
+    ["CTLTYPE_STRING", "kern.ostype", "string"],
+    ["CTLTYPE_U8", "kern.poweroff_on_panic", "uint8_t"],
+    ["CTLTYPE_U64", "kern.epoch.stats.epoch_calls", "uint64_t"],
+    ["CTLTYPE_UINT", "kern.maxvnodes", "unsigned integer"],
+    ["CTLTYPE_LONG", "vm.kvm_size", "long integer"],
+    ["CTLTYPE_ULONG", "vm.kmem_size", "unsigned long"]
+]
+
+@pytest.mark.parametrize("item", WELL_KNOWNS)
+def test_explicit_list_of_sysctl_value(item):
+
+    sysctl_name = item[1]
+
+    sysctl = freebsd_sysctl.Sysctl(sysctl_name)
+
+    stdout = subprocess.check_output([
+        "/sbin/sysctl",
+        "-n",
+        sysctl_name
+    ]).strip().decode()
+
+    assert str(sysctl.value) == stdout
+
 def test_sysctl_values(benchmark, sysctl_types):
 
     dynamic_sysctl_names = [


### PR DESCRIPTION
This is based on my suggestion.

I'm not sure about your coding style, ordering of test cases, etc.

Feel free to rename function, variables, and/or locations of variables and function or even  not to accept the change.  I made the test function name extra verbose.

I like this type of small test case because it can easily pin-point what failed.
Fixing 1 issue changes 1 failing test case to a success.
It also quick and easy increase of test cases and coverage ;)

```
[py-venv] % python -m pytest -k test_explicit_list_of_sysctl_value
...
tests/freebsd_sysctl_test.py::test_explicit_list_of_sysctl_value[item0] PASSED [ 14%]
tests/freebsd_sysctl_test.py::test_explicit_list_of_sysctl_value[item1] PASSED [ 28%]
tests/freebsd_sysctl_test.py::test_explicit_list_of_sysctl_value[item2] PASSED [ 42%]
tests/freebsd_sysctl_test.py::test_explicit_list_of_sysctl_value[item3] PASSED [ 57%]
tests/freebsd_sysctl_test.py::test_explicit_list_of_sysctl_value[item4] PASSED [ 71%]
tests/freebsd_sysctl_test.py::test_explicit_list_of_sysctl_value[item5] PASSED [ 85%]
tests/freebsd_sysctl_test.py::test_explicit_list_of_sysctl_value[item6] PASSED [100%]

======================= 7 passed, 5 deselected in 0.10s ========================
```