### PR TITLE
Sysctl::fmt() to return str type.

### DIFF
--- a/freebsd_sysctl/__init__.py
+++ b/freebsd_sysctl/__init__.py
@@ -42,7 +42,7 @@ class Sysctl:
     _name: typing.Optional[str]
     _oid: typing.Optional[typing.List[int]]
     _kind: typing.Optional[int]
-    _fmt = typing.Optional[bytes]
+    _fmt = typing.Optional[str]
     _size: typing.Optional[int]
     _value: typing.Optional[typing.Any]
     _description: typing.Optional[str]
@@ -176,7 +176,7 @@ class Sysctl:
         return buf.value.decode()
 
     @staticmethod
-    def query_fmt(oid: typing.List[int]) -> typing.Tuple[int, bytes]:
+    def query_fmt(oid: typing.List[int]) -> typing.Tuple[int, str]:
 
         qoid_len = (2 + len(oid))
         qoid_type = ctypes.c_int * qoid_len
@@ -204,7 +204,8 @@ class Sysctl:
             raise Exception("response buffer too small")
         result = buf[:buf_length]
         kind, = struct.unpack("I", result[:4])
-        fmt = result[4:]
+        null_pos = result.find(b'\x00',4) # buf is large and string is small
+        fmt = result[4:null_pos].decode()
         return (kind, fmt)
 
     @staticmethod

--- a/tests/freebsd_sysctl_test.py
+++ b/tests/freebsd_sysctl_test.py
@@ -87,6 +87,22 @@ def test_sysctl_types(sysctl_types):
         current_mapped_type = map_sysctl_type(current_sysctl.ctl_type)
         assert sysctl_type == current_mapped_type, sysctl_name
 
+OPAQUES = [
+    ("kern.clockrate", "S,clockinfo"),
+    ("vm.loadavg", "S,loadavg"),
+    ("kern.boottime", "S,timeval"),
+    ("vm.vmtotal", "S,vmtotal"),
+    # ("", "S,input_id"), # doesn't seem to exist
+    ("hw.pagesizes.", "S,pagesizes")
+    # ("", "S,efi_map_header"), # amd64 only
+    # ("machdep.smap", "S,bios_smap_xattr"), # amd64/i386 only
+]
+
+@pytest.mark.parametrize("sysctl_name, expected", OPAQUES)
+def test_sysctl_opaque_fmt(sysctl_name, expected):
+    sysctl = freebsd_sysctl.Sysctl(sysctl_name)
+    assert sysctl.fmt == expected
+
 
 WELL_KNOWNS = [
     # sysctl-type-name, sysctl name, sysctl -t


### PR DESCRIPTION
A NULL-terminated string comes after an unsinged integer of kind field.
This field will be useful to convert opaque types.