### PR TITLE
Implement refresh() to fetch a new value

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,17 +20,8 @@ It is meant for performant (read) access to sysctls, their type, value and descr
 180054
 >>> free_count.value
 180054
->>> free_count.refresh()
-180054
 >>> b = bytearray(100*1024*1024)
->>> free_count.refresh()
-152667
 >>> b = None
->>> free_count.refresh()
-176879
->>> free_count.value
-176879
->>> b = bytearray(100*1024*1024)
 >>> free_count.value
 176879
 ```
@@ -50,15 +41,9 @@ With either a sysctl `name` or `oid` the other properties provide memoized acces
 
 | Read Property Name | Description |
 | ------------- | ----------- |
-| `value`       | Value of a sysctl. `sysctl <name>` |
+| `value`       | Value of a sysctl. `sysctl <name>` Each call fetches a new value. |
 | `ctl_type`    | sysctl type class. `sysctl -t <name>` |
 | `description` | Text description of the sysctl. `sysctl -d <name>` |
-
-## Function
-
-| Function Name | Return Value | Description |
-| ------------- | ------------ | ----------- |
-| `refresh()`   | `value`      | Fetch a new value of the same sysctl. |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -14,9 +14,28 @@ It is meant for performant (read) access to sysctls, their type, value and descr
 <class 'freebsd_sysctl.types.INT'>
 >>> Sysctl("security.jail.enforce_statfs").description
 'Processes in jail cannot see all mounted file systems (deprecated)'
+
+>>> free_count = Sysctl("vm.stats.vm.v_free_count")
+>>> free_count.value
+180054
+>>> free_count.value
+180054
+>>> free_count.refresh()
+180054
+>>> b = bytearray(100*1024*1024)
+>>> free_count.refresh()
+152667
+>>> b = None
+>>> free_count.refresh()
+176879
+>>> free_count.value
+176879
+>>> b = bytearray(100*1024*1024)
+>>> free_count.value
+176879
 ```
 
-With either a sysctl `name` or `oid` the other properties provide memoized access to lazy-loaded properties.
+With either a sysctl `name` or `oid` the other properties provide memorized access to lazy-loaded properties.
 
 ## Properties
 
@@ -34,6 +53,12 @@ With either a sysctl `name` or `oid` the other properties provide memoized acces
 | `value`       | Value of a sysctl. `sysctl <name>` |
 | `ctl_type`    | sysctl type class. `sysctl -t <name>` |
 | `description` | Text description of the sysctl. `sysctl -d <name>` |
+
+## Function
+
+| Function Name | Return Value | Description |
+| ------------- | ------------ | ----------- |
+| `refresh()`   | `value`      | Fetch a new value of the same sysctl. |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ It is meant for performant (read) access to sysctls, their type, value and descr
 176879
 ```
 
-With either a sysctl `name` or `oid` the other properties provide memorized access to lazy-loaded properties.
+With either a sysctl `name` or `oid` the other properties provide memoized access to lazy-loaded properties.
 
 ## Properties
 

--- a/freebsd_sysctl/__init__.py
+++ b/freebsd_sysctl/__init__.py
@@ -125,6 +125,10 @@ class Sysctl:
             yield current
             current = current.next
 
+    def refresh(self) -> typing.Any:
+        self._value = None
+        return self.value
+
     def __query_kind_and_fmt(self) -> None:
         self._kind, self._fmt = self.query_fmt(self.oid)
 

--- a/freebsd_sysctl/__init__.py
+++ b/freebsd_sysctl/__init__.py
@@ -44,7 +44,6 @@ class Sysctl:
     _kind: typing.Optional[int]
     _fmt = typing.Optional[str]
     _size: typing.Optional[int]
-    _value: typing.Optional[typing.Any]
     _description: typing.Optional[str]
 
     def __init__(
@@ -57,7 +56,6 @@ class Sysctl:
         self._kind = None
         self._fmt = None
         self._size = None
-        self._value = None
         self._description = None
 
     @property
@@ -96,15 +94,14 @@ class Sysctl:
 
     @property
     def raw_value(self) -> typing.Any:
-        if self._value is None:
-            self._value = self.query_value(self.oid, self.size, self.ctl_type)
-        return self._value
+        return self.query_value(self.oid, self.size, self.ctl_type)
 
     @property
     def value(self) -> typing.Any:
-        if type(self.raw_value.value) == str:
-            return self.raw_value.value.strip("\n")
-        return self.raw_value.value
+        v = self.raw_value.value
+        if type(v) == str:
+            return v.strip("\n")
+        return v
 
     @property
     def description(self) -> str:
@@ -124,10 +121,6 @@ class Sysctl:
         while self.oid == current.oid[:len(self.oid)]:
             yield current
             current = current.next
-
-    def refresh(self) -> typing.Any:
-        self._value = None
-        return self.value
 
     def __query_kind_and_fmt(self) -> None:
         self._kind, self._fmt = self.query_fmt(self.oid)

--- a/tests/freebsd_sysctl_test.py
+++ b/tests/freebsd_sysctl_test.py
@@ -222,3 +222,12 @@ def test_security_jail_param_list(benchmark):
     assert all([a == b for a, b in zip(test_node_child_names, child_names)]), (
         "the order of children or their names differed"
     )
+
+def test_sysctl_refresh():
+    sysctl = freebsd_sysctl.Sysctl("vm.stats.vm.v_free_count")
+    last = sysctl.value
+    list = []
+    for i in range(10):
+        list.append(bytearray(10 * 1024 * 1024))
+        assert last != sysctl.refresh()
+        last = sysctl.value

--- a/tests/freebsd_sysctl_test.py
+++ b/tests/freebsd_sysctl_test.py
@@ -229,5 +229,5 @@ def test_sysctl_refresh():
     list = []
     for i in range(10):
         list.append(bytearray(10 * 1024 * 1024))
-        assert last != sysctl.refresh()
+        assert last != sysctl.value
         last = sysctl.value


### PR DESCRIPTION
This is twice faster than instantiating another Sysctl for the same sysctl
because we can avoid 1 sysctl call to figure out kind/fmt.

We can further optimize by not instantiating CtlType with fresh data each time
but rather have a CtlType's conversion function takes bytes.